### PR TITLE
Super KA

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -42,6 +42,7 @@
 		new /datum/data/mining_equipment("Super Resonator",				/obj/item/resonator/upgraded,										2500),
 		new /datum/data/mining_equipment("Jump Boots",					/obj/item/clothing/shoes/bhop,										2500),
 		new /datum/data/mining_equipment("Luxury Shelter Capsule",		/obj/item/survivalcapsule/luxury,									3000),
+		new /datum/data/mining_equipment("Super Kinetic Accelerator",	/obj/item/gun/energy/kinetic_accelerator/super_kinetic_accelerator,	4000),
 		new /datum/data/mining_equipment("Nanotrasen Minebot",			/mob/living/simple_animal/hostile/mining_drone,						800),
 		new /datum/data/mining_equipment("Minebot Melee Upgrade",		/obj/item/mine_bot_upgrade,											400),
 		new /datum/data/mining_equipment("Minebot Armor Upgrade",		/obj/item/mine_bot_upgrade/health,									400),

--- a/code/shitcode/ClickerOfThings/super_kinetic/super_kinetic_accelerator.dm
+++ b/code/shitcode/ClickerOfThings/super_kinetic/super_kinetic_accelerator.dm
@@ -1,0 +1,35 @@
+/obj/item/gun/energy/kinetic_accelerator/super_kinetic_accelerator
+	name = "super proto-kinetic accelerator"
+	desc = "A self recharging, ranged mining tool that does increased damage in low pressure, now with more mod capacity! But without damage..."
+	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/decreased_damage)
+	max_mod_capacity = 250
+
+	// add here mods that CAN be attached
+	var/accept_mods = list(/obj/item/borg/upgrade/modkit/aoe/turfs,
+	/obj/item/borg/upgrade/modkit/cooldown,
+	/obj/item/borg/upgrade/modkit/range,
+	/obj/item/borg/upgrade/modkit/minebot_passthrough,
+	/obj/item/borg/upgrade/modkit/trigger_guard,
+	/obj/item/borg/upgrade/modkit/chassis_mod,
+	/obj/item/borg/upgrade/modkit/chassis_mod/orange,
+	/obj/item/borg/upgrade/modkit/tracer,
+	/obj/item/borg/upgrade/modkit/tracer/adjustable)
+
+/obj/item/gun/energy/kinetic_accelerator/super_kinetic_accelerator/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/borg/upgrade/modkit))
+		var/list/mods_can_be_added = src.accept_mods
+		for(var/counter = 1; counter <= mods_can_be_added.len; counter++)
+			if(istype(I, mods_can_be_added[counter]) && ispath(mods_can_be_added[counter], I))
+				var/obj/item/borg/upgrade/modkit/MK = I
+				MK.install(src, user)
+				return
+		to_chat(user, "<span class='warning'>You can't install that mod!</span>")
+		return
+	else
+		..()
+
+/obj/item/projectile/kinetic/decreased_damage
+	damage = 5
+
+/obj/item/ammo_casing/energy/kinetic/decreased_damage
+	projectile_type = /obj/item/projectile/kinetic

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2923,6 +2923,7 @@
 #include "code\shitcode\ClickerOfThings\integrated_circuits_snitch\integrated_electronics\subtypes\trig.dm"
 #include "code\shitcode\ClickerOfThings\shitspawn_deck\shitspawn_deck.dm"
 #include "code\shitcode\ClickerOfThings\steklotara\punkt_priema.dm"
+#include "code\shitcode\ClickerOfThings\super_kinetic\super_kinetic_accelerator.dm"
 #include "code\shitcode\fogmann\donations.dm"
 #include "code\shitcode\fogmann\fogmann.dm"
 #include "code\shitcode\fogmann\funmote.dm"


### PR DESCRIPTION
# Встречайте майнеродрочество нового поколения - **Супер Кинетик Аксебульбулятор™**.
Главная особенность **Супер Кинетик Аксебульбулятора™** в том, что емкость для улучшений увеличен в **2,5 раза**! Но, это не обходится без минусов - **нельзя** устанавливать модификации, связанные с **уроном**. Также, **снижен урон** самого снаряда, выпускаемого из **Супер Кинетик Аксебульбулятора™**.
Сделано это для тех, кто не любит церемониться с часовыми побегами по лаваленду в поисках всех ресурсов и ожидания перезарядки.
Взять данную чудесную вещь можно в шахтёрском автомате за 4 куска очков, получаемых с плавильни руд.

Если у вас есть своя модификация для КА, и вы хотите, чтобы его можно было вставить в **Супер Кинетик Аксебульбулятор™**, то стоит добавить тип модкита в специально сделанный для этого список. Самое главное - **это улучшение не должно быть связано с уроном!**